### PR TITLE
Automatically exec after route.start()

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -134,6 +134,21 @@ route.start()
 Riot doesn't `start` its router automatically. DON'T FORGET TO START IT BY YOURSELF. This also means that you can choose your favorite router.
 (Note: before v2.3 Riot started the router automatically. The behavior was changed)
 
+### route.start(autoExec)
+
+Start listening the url changes and also exec routing on the current url.
+
+```js
+route.start(true)
+```
+
+This is a shorthand for:
+
+```js
+route.start()
+route.exec()
+```
+
 ### route.stop()
 
 Stop all the routings. It'll removes the listeners and clear also the callbacks.

--- a/lib/index.js
+++ b/lib/index.js
@@ -257,13 +257,17 @@ route.stop = function () {
   }
 }
 
-/** Start routing **/
-route.start = function () {
+/**
+ * Start routing
+ * @param {boolean} autoExec - automatically exec after starting if true
+ */
+route.start = function (autoExec) {
   if (!started) {
     win[ADD_EVENT_LISTENER](POPSTATE, emit)
     doc[ADD_EVENT_LISTENER](clickEvent, click)
     started = true
   }
+  if (autoExec) emit(true)
 }
 
 /** Prepare the router **/

--- a/test/specs/core.specs.js
+++ b/test/specs/core.specs.js
@@ -232,6 +232,16 @@ describe('Core specs', function() {
     expect(counter).to.be(2)
   })
 
+  it('start with autoExec option', function() {
+    route.base('/')
+    route(function() {
+      counter++
+    })
+    var autoExec = true
+    route.start(autoExec)
+    expect(counter).to.be(1)
+  })
+
   it('sets routings in weird order', function() {
     route.base('/')
     route(function() {


### PR DESCRIPTION
We need to start the router manually after v2.3. So in many case `start` + `exec` is called together:

```js
riot.mount('*')
riot.route.start()
riot.route.exec()
```

My proposal is to provide shorthand of this:

```js
riot.mount('*')
riot.route.start(true)
```

Thoughts?

(Personally I think `route.start()` should fire `exec` implicitly, but it could break the existing codes)