### PR TITLE
update for html history polyfill for ie =< 9

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -5,8 +5,8 @@ The Riot Router is the minimal router implementation with such technologies:
 - pushState and history API
 - multiple routing groups
 - replacable parser
-- compatible with IE9 and higher
-
+- use a [polyfill](https://github.com/devote/HTML5-History-API) for ie9 support and earlier.  Because ie.
+ 
 ## Setup routing
 
 ### route(callback)


### PR DESCRIPTION
riot router relies on pushState - which is not supported in ie =< 9.  Updating docs with reference to a polyfill