### PR TITLE
Server-side support (part 1: safety)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build:
 watch:
 	@ $(CHOKIDAR) lib/* lib/**/* -c 'make build'
 
-test: eslint test-karma
+test: eslint test-karma test-server
 
 test-browsers:
 	@ BROWSERSTACK=1 $(KARMA) start test/karma.conf.js
@@ -63,6 +63,9 @@ eslint:
 
 test-karma:
 	@ $(KARMA) start test/karma.conf.js
+
+test-server:
+	@ $(MOCHA) test/specs/server.specs.js
 
 test-coveralls:
 	@ RIOT_COV=1 cat ./coverage/lcov.info ./coverage/report-lcov/lcov.info | $(COVERALLS)

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,9 +15,10 @@ var RE_ORIGIN = /^.+?\/+[^\/]+/,
   HASHCHANGE = 'hashchange',
   TRIGGER = 'trigger',
   MAX_EMIT_STACK_LEVEL = 3,
-  win = window,
-  doc = document,
-  loc = win.history.location || win.location, // see html5-history-api
+  win = typeof window != 'undefined' && window,
+  doc = typeof document != 'undefined' && document,
+  hist = win && history,
+  loc = win && (hist.location || win.location), // see html5-history-api
   prot = Router.prototype, // to minify more
   clickEvent = doc && doc.ontouchstart ? 'touchstart' : 'click',
   started = false,
@@ -98,7 +99,7 @@ function isString(str) {
  * @returns {string} path from root
  */
 function getPathFromRoot(href) {
-  return (href || loc.href)[REPLACE](RE_ORIGIN, '')
+  return (href || loc.href || '')[REPLACE](RE_ORIGIN, '')
 }
 
 /**
@@ -108,7 +109,7 @@ function getPathFromRoot(href) {
  */
 function getPathFromBase(href) {
   return base[0] == '#'
-    ? (href || loc.href).split(base)[1] || ''
+    ? (href || loc.href || '').split(base)[1] || ''
     : getPathFromRoot(href)[REPLACE](base, '')
 }
 
@@ -171,7 +172,7 @@ function click(e) {
 function go(path, title) {
   title = title || doc.title
   // browsers ignores the second parameter `title`
-  history.pushState(null, title, base + normalize(path))
+  hist && hist.pushState(null, title, base + normalize(path))
   // so we need to set it manually
   doc.title = title
   routeFound = false
@@ -279,16 +280,19 @@ route.parser = function(fn, fn2) {
  */
 route.query = function() {
   var q = {}
-  loc.href[REPLACE](/[?&](.+?)=([^&]*)/g, function(_, k, v) { q[k] = v })
+  var href = loc.href || current
+  href[REPLACE](/[?&](.+?)=([^&]*)/g, function(_, k, v) { q[k] = v })
   return q
 }
 
 /** Stop routing **/
 route.stop = function () {
   if (started) {
-    win[REMOVE_EVENT_LISTENER](POPSTATE, debouncedEmit)
-    win[REMOVE_EVENT_LISTENER](HASHCHANGE, debouncedEmit)
-    doc[REMOVE_EVENT_LISTENER](clickEvent, click)
+    if (win) {
+      win[REMOVE_EVENT_LISTENER](POPSTATE, debouncedEmit)
+      win[REMOVE_EVENT_LISTENER](HASHCHANGE, debouncedEmit)
+      doc[REMOVE_EVENT_LISTENER](clickEvent, click)
+    }
     central[TRIGGER]('stop')
     started = false
   }
@@ -300,12 +304,14 @@ route.stop = function () {
  */
 route.start = function (autoExec) {
   if (!started) {
-    if (document.readyState == 'complete') start(autoExec)
-    // the timeout is needed to solve
-    // a weird safari bug https://github.com/riot/route/issues/33
-    else win[ADD_EVENT_LISTENER]('load', function() {
-      setTimeout(function() { start(autoExec) }, 1)
-    })
+    if (win) {
+      if (document.readyState == 'complete') start(autoExec)
+      // the timeout is needed to solve
+      // a weird safari bug https://github.com/riot/route/issues/33
+      else win[ADD_EVENT_LISTENER]('load', function() {
+        setTimeout(function() { start(autoExec) }, 1)
+      })
+    }
     started = true
   }
 }

--- a/test/specs/server.specs.js
+++ b/test/specs/server.specs.js
@@ -1,0 +1,46 @@
+var route  = require('../../lib/index')
+var expect = require('expect.js')
+
+describe('Server-side specs', function() {
+  it('does not crash when included on server', function() {
+    expect(1).to.be.ok()
+  })
+
+  describe('Public API can safely be called on server', function() {
+    it('can start and stop', function() {
+      expect(route.start).to.not.throwException()
+      expect(route.start).withArgs(true).to.not.throwException()
+      expect(route.stop).to.not.throwException()
+    })
+
+    it('can set a base', function() {
+      expect(route.base).withArgs('/').to.not.throwException()
+    })
+
+    it('can create sub route context', function() {
+      expect(route.create).to.not.throwException()
+    })
+    
+    it('can define route handlers', function() {
+      expect(route).withArgs(function(){}).to.not.throwException()
+      expect(route).withArgs('/fruit', function(){}).to.not.throwException()
+    })
+
+    it('can call route to', function() {
+      expect(route).withArgs('/fruit').to.not.throwException()
+      expect(route).withArgs('/fruit', 'Fruit').to.not.throwException()
+    })
+
+    it('can call query', function() {
+      expect(route.query).to.not.throwException()
+    })
+
+    it('can call exec', function() {
+      expect(route.exec).to.not.throwException()
+    })
+
+    it('can set parsers', function() {
+      expect(route.parser).withArgs(function(){}, function(){}).to.not.throwException()
+    })
+  })
+})


### PR DESCRIPTION
This simply allows the route library to be safely included in a server environment without crashing.
It also tests that all public APIs can be called server-side without crashing.

I will create a follow-up PR that adds an API method so that you can actually execute and handle routing on the server.

@cognitom @GianlucaGuarini 