### PR TITLE
Server-side support (part 2 of 2: api)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -184,10 +184,9 @@ subRoute('/fruit/apple', function() { /* */ })
 subRoute.stop()
 ```
 
-### route.exec([path])
+### route.exec()
 
 Study the current browser path "in place" and emit routing without waiting for it to change.  
-For server-side support, the optional `path` parameter needs to be provided from the server.
 
 ```javascript
 route(function() { /* define routing */ })

--- a/lib/index.js
+++ b/lib/index.js
@@ -170,14 +170,19 @@ function click(e) {
  * @returns {boolean} - route not found flag
  */
 function go(path, title) {
-  title = title || doc.title
-  // browsers ignores the second parameter `title`
-  hist && hist.pushState(null, title, base + normalize(path))
-  // so we need to set it manually
-  doc.title = title
-  routeFound = false
-  emit()
-  return routeFound
+  if (hist) { // if a browser
+    title = title || doc.title
+    // browsers ignores the second parameter `title`
+    hist.pushState(null, title, base + normalize(path))
+    // so we need to set it manually
+    doc.title = title
+    routeFound = false
+    emit()
+    return routeFound
+  }
+
+  // Server-side usage: directly execute handlers for the path
+  return central[TRIGGER]('emit', getPathFromBase(path))
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "riot-route",
   "version": "2.3.12",
-  "description": "Simple client-side router",
+  "description": "Simple isomorphic router",
   "main": "lib/index.js",
   "jsnext:main": "lib/es6.route.js",
   "directories": {

--- a/test/specs/server.specs.js
+++ b/test/specs/server.specs.js
@@ -2,8 +2,22 @@ var route  = require('../../lib/index')
 var expect = require('expect.js')
 
 describe('Server-side specs', function() {
+
   it('does not crash when included on server', function() {
     expect(1).to.be.ok()
+  })
+
+  it('can go to routes on server', function() {
+    var counter = 0
+  
+    route.base('/')
+    route('/fruit', function() {
+      counter++
+    })
+
+    route('/veg')
+    route('/fruit')
+    expect(counter).to.equal(1)
   })
 
   describe('Public API can safely be called on server', function() {


### PR DESCRIPTION
This is a follow up to part 1 (#43) of server-side support.  The api method to go to a route: `route(path)` now works server-side.

~~This adds  a new API method: `route.render(path)` so your route handlers can be directly executed on the server. Alternatively, we could allow the existing `route.exec()` to accept an optional `path` parameter, which I did in my first implementation (#19 (reverted))~~
