### PR TITLE
Server-side bug fix: paths with multiple slashes were incorrectly parsed from root

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@
 
 var observable = require('riot-observable')
 
-var RE_ORIGIN = /^.+?\/+[^\/]+/,
+var RE_ORIGIN = /^.+?\/\/+[^\/]+/,
   EVENT_LISTENER = 'EventListener',
   REMOVE_EVENT_LISTENER = 'remove' + EVENT_LISTENER,
   ADD_EVENT_LISTENER = 'add' + EVENT_LISTENER,
@@ -99,7 +99,7 @@ function isString(str) {
  * @returns {string} path from root
  */
 function getPathFromRoot(href) {
-  return (href || loc.href || '')[REPLACE](RE_ORIGIN, '')
+  return (href || loc.href)[REPLACE](RE_ORIGIN, '')
 }
 
 /**
@@ -110,7 +110,7 @@ function getPathFromRoot(href) {
 function getPathFromBase(href) {
   return base[0] == '#'
     ? (href || loc.href || '').split(base)[1] || ''
-    : getPathFromRoot(href)[REPLACE](base, '')
+    : (loc ? getPathFromRoot(href) : href || '')[REPLACE](base, '')
 }
 
 function emit(force) {

--- a/test/specs/server.specs.js
+++ b/test/specs/server.specs.js
@@ -9,15 +9,19 @@ describe('Server-side specs', function() {
 
   it('can go to routes on server', function() {
     var counter = 0
-  
+
     route.base('/')
     route('/fruit', function() {
+      counter++
+    })
+    route('/fruit/apples', function() {
       counter++
     })
 
     route('/veg')
     route('/fruit')
-    expect(counter).to.equal(1)
+    route('/fruit/apples')
+    expect(counter).to.equal(2)
   })
 
   describe('Public API can safely be called on server', function() {
@@ -34,7 +38,7 @@ describe('Server-side specs', function() {
     it('can create sub route context', function() {
       expect(route.create).to.not.throwException()
     })
-    
+
     it('can define route handlers', function() {
       expect(route).withArgs(function(){}).to.not.throwException()
       expect(route).withArgs('/fruit', function(){}).to.not.throwException()


### PR DESCRIPTION
A path with multiple slashes e.g. `'/fruit/apples'` was being incorrectly reduced to `''` by `getPathFromRoot`.

That method no longer attempts to remove the origin (`var RE_ORIGIN = /^.+?\/+[^\/]+/`), which doesn't exist on a server.