### PR TITLE
Fix sub-route termination

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -250,10 +250,11 @@ var route = mainRouter.m.bind(mainRouter)
  */
 route.create = function() {
   var newSubRouter = new Router()
+  // assign sub-router's main method
+  var router = newSubRouter.m.bind(newSubRouter)
   // stop only this sub-router
-  newSubRouter.m.stop = newSubRouter.s.bind(newSubRouter)
-  // return sub-router's main method
-  return newSubRouter.m.bind(newSubRouter)
+  router.stop = newSubRouter.s.bind(newSubRouter)
+  return router
 }
 
 /**

--- a/test/specs/server.specs.js
+++ b/test/specs/server.specs.js
@@ -9,7 +9,7 @@ describe('Server-side specs', function() {
 
   it('can go to routes on server', function() {
     var counter = 0
-  
+
     route.base('/')
     route('/fruit', function() {
       counter++
@@ -34,7 +34,12 @@ describe('Server-side specs', function() {
     it('can create sub route context', function() {
       expect(route.create).to.not.throwException()
     })
-    
+
+    it('can terminate sub route context', function() {
+      var subRoute = route.create()
+      expect(subRoute.stop).to.not.throwException()
+    })
+
     it('can define route handlers', function() {
       expect(route).withArgs(function(){}).to.not.throwException()
       expect(route).withArgs('/fruit', function(){}).to.not.throwException()


### PR DESCRIPTION
This should fix #51.

I shamelessly copied the test code from https://github.com/riot/route/issues/51#issue-128427555 (thanks, @wiz).

Instead of just returning a function that loses the object context of itself, now the `stop()` function directly sits on the instance.