### PR TITLE
Fix PhantomJS testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "karma-coverage": "^0.5.5",
     "karma-mocha": "^0.2.2",
     "karma-mocha-reporter": "^2.0.0",
-    "karma-phantomjs-launcher": "^1.0.0",
+    "karma-phantomjs-launcher": "^0.2.3",
     "mocha": "^2.4.5",
-    "phantomjs-prebuilt": "^2.1.6",
+    "phantomjs": "^1.9.19",
     "uglify-js": "^2.6.2"
   },
   "author": "Muut, Inc. and other contributors",


### PR DESCRIPTION
Downgrade PhantomJS back to 1.x so all the specs run.
I suspect that the history and location manipulation of this lib may have to be mocked to run in Phantom 2.x.