### PR TITLE
Externalized normalize (like parsers) so regexp can allow trailing slashes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ var RE_ORIGIN = /^.+?\/\/+[^\/]+/,
   central = observable(),
   routeFound = false,
   debouncedEmit,
-  base, current, parser, secondParser, emitStack = [], emitStackLevel = 0
+  base, current, parser, normalize, secondParser, emitStack = [], emitStackLevel = 0
 
 /**
  * Default parser. You can replace it via router.parser method.
@@ -85,7 +85,7 @@ function Router() {
   central.on('emit', this.e.bind(this))
 }
 
-function normalize(path) {
+function DEFAULT_NORMALIZE(path) {
   return path[REPLACE](/^\/|\/$/, '')
 }
 
@@ -268,6 +268,17 @@ route.exec = function() {
 }
 
 /**
+ * Replace the default normalize to yours
+ * @param {function} fn - your normalize function
+ */
+route.normalize = function(fn){
+	if(!fn)
+		normalize = DEFAULT_NORMALIZE
+	else
+		normalize = fn
+}
+
+/**
  * Replace the default router to yours
  * @param {function} fn - your parser function
  * @param {function} fn2 - your secondParser function
@@ -327,5 +338,6 @@ route.start = function (autoExec) {
 /** Prepare the router **/
 route.base()
 route.parser()
+route.normalize()
 
 module.exports = route

--- a/lib/index.js
+++ b/lib/index.js
@@ -272,10 +272,10 @@ route.exec = function() {
  * @param {function} fn - your normalize function
  */
 route.normalize = function(fn){
-	if(!fn)
-		normalize = DEFAULT_NORMALIZE
-	else
-		normalize = fn
+  if (!fn)
+    normalize = DEFAULT_NORMALIZE
+  else
+    normalize = fn
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -271,7 +271,7 @@ route.exec = function() {
  * Replace the default normalize to yours
  * @param {function} fn - your normalize function
  */
-route.normalize = function(fn){
+route.normalize = function(fn) {
   if (!fn)
     normalize = DEFAULT_NORMALIZE
   else

--- a/test/specs/core.specs.js
+++ b/test/specs/core.specs.js
@@ -458,6 +458,9 @@ describe('Core specs', function() {
   })
 
   it('custom normalize', function() {
+	var str
+    route.base('/')
+	
     route.normalize(function(path) {
       return path.replace(/^\//, '')
     })

--- a/test/specs/core.specs.js
+++ b/test/specs/core.specs.js
@@ -76,6 +76,7 @@ describe('Core specs', function() {
     route.stop() // detouch all routings
     route.base() // reset base
     route.parser() // reset parser
+	route.normalize() // reset normalize
     route.start() // start router again
   })
 
@@ -344,6 +345,19 @@ describe('Core specs', function() {
     route('test')
     route('/')
     expect(counter).to.be(2)
+  })
+  
+  it('custom normalize', function() {
+    route.normalize(function(path) {
+      return path.replace(/^\//, '')
+    })
+    route(function(first) {
+      counter++
+      expect(first).to.be('vegitable')
+    })
+    route('/vegitable/')
+	expect(window.location.pathname).to.be('/vegitable/')
+	expect(counter).to.be(1)
   })
 
   it('custom second parser', function() {

--- a/test/specs/core.specs.js
+++ b/test/specs/core.specs.js
@@ -346,19 +346,6 @@ describe('Core specs', function() {
     route('/')
     expect(counter).to.be(2)
   })
-  
-  it('custom normalize', function() {
-    route.normalize(function(path) {
-      return path.replace(/^\//, '')
-    })
-    route(function(first) {
-      counter++
-      expect(first).to.be('vegitable')
-    })
-    route('/vegitable/')
-	expect(window.location.pathname).to.be('/vegitable/')
-	expect(counter).to.be(1)
-  })
 
   it('custom second parser', function() {
     route.base('/')
@@ -376,6 +363,9 @@ describe('Core specs', function() {
     expect(counter).to.be(4)
   })
 
+    
+
+  
   it('metakeys events get skipped', function() {
 
     route(function() {
@@ -467,6 +457,19 @@ describe('Core specs', function() {
     expect(counter).to.be(3)
   })
 
+  it('custom normalize', function() {
+    route.normalize(function(path) {
+      return path.replace(/^\//, '')
+    })
+    route(function(first) {
+      counter++
+      expect(first).to.be('vegitable')
+    })
+    route('/vegitable/')
+	expect(window.location.pathname).to.be('/vegitable/')
+	expect(counter).to.be(1)
+  })
+  
   it('push and replace', function(done) {
     route.base('/')
     route(function() {


### PR DESCRIPTION
In cases you don't mind trailing slash, you'd use

```
router.normalize(fn(path){
  return path[REPLACE](/^\//, '')
})
```

I've run into this problem when I've tried to run routes like:
`/player/`
`/player/:id/`
and then routing by relative links (`href="images/"` not `href="/player/:id/images/"`)

It was caused by normalize function replacing trailing slashes. 
