### PR TITLE
Start when readyState is interactive

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -326,12 +326,18 @@ route.stop = function () {
 route.start = function (autoExec) {
   if (!started) {
     if (win) {
-      if (document.readyState === 'complete') start(autoExec)
-      // the timeout is needed to solve
-      // a weird safari bug https://github.com/riot/route/issues/33
-      else win[ADD_EVENT_LISTENER]('load', function() {
-        setTimeout(function() { start(autoExec) }, 1)
-      })
+      if (document.readyState === 'interactive' || document.readyState === 'complete') {
+        start(autoExec)
+      }
+      else {
+        document.onreadystatechange = function () {
+          if (document.readyState === 'interactive') {
+            // the timeout is needed to solve
+            // a weird safari bug https://github.com/riot/route/issues/33
+            setTimeout(function() { start(autoExec) }, 1)
+          }
+        }
+      }
     }
     started = true
   }


### PR DESCRIPTION
By starting when readyState is interactive the router does not block the app until all resources are loaded. This is currently a problem with slow loading third party scripts.
