### PR TITLE
Adds autoForce option to start()

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -159,27 +159,34 @@ Start listening the url changes.
 route.start()
 ```
 
-<span class="tag red">&gt;= v2.3</span>
+<span class="tag red">&gt;= v3.2</span>
 
 Riot doesn't `start` its router automatically. DON'T FORGET TO START IT BY YOURSELF. This also means that you can choose your favorite router.
 (Note: before v2.3 Riot started the router automatically. The behavior was changed)
 
-### route.start(autoExec)
+### route.start(options)
 
-Start listening the url changes and also exec routing on the current url.
+Start listening the url changes and also specify some options of behavior.
+
+ - `autoExec`: Exec routing on the current url
+ - `autoForce`: Force routing of even "same page" routes
+
+For backwards compatibility support, you may set `options` to `true` which is setting `autoExec` as `true`.
 
 ```js
 route.start(true)
+// OR
+route.start({autoExec: true})
 ```
 
-This is a shorthand for:
+Are both shorthand for:
 
 ```js
 route.start()
 route.exec()
 ```
 
-<span class="tag red">&gt;= v2.3</span>
+<span class="tag red">&gt;= v3.2</span>
 
 Riot doesn't `start` its router automatically. DON'T FORGET TO START IT BY YOURSELF. This also means that you can choose your favorite router.
 (Note: before v2.3 Riot started the router automatically. The behavior was changed)

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ function debounce(fn, delay) {
  * @param {object} opts
  */
 function start(opts) {
-  options = opts || {};
+  options = opts || {}
   if (options === true) {
     // Backwards Compatability
     options = { autoExec: true }
@@ -131,7 +131,7 @@ function getPathFromBase(href) {
 }
 
 function emit(force) {
-  force = force || options.autoForce;
+  force = force || options.autoForce
   // the stack is needed for redirections
   const isRoot = emitStackLevel === 0
   if (MAX_EMIT_STACK_LEVEL <= emitStackLevel) return
@@ -181,7 +181,7 @@ function click(e) {
 
   if (!go(getPathFromBase(el.href), el.title || doc.title)) {
     // route not found
-    return;
+    return
   }
 
   e.preventDefault()


### PR DESCRIPTION
This allows for any app to enable the option to route to the current
href. Currently, links to the current page are ignored. This feature has
been implemented in a BC manner. Existing code will still work as usual.

fixes #105