### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ edition | target | file | via
 ### jsdelivr
 
 ```html
-<script src="https://cdn.jsdelivr.net/riot-route/x.x.x/route.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/riot-route@x.x.x/dist/route.min.js"></script>
 ```
 
 *Note*: change the part `x.x.x` to the version numbers what you want to use: ex. `2.5.0` or `3.0.0`.


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/riot-route.

Feel free to ping me if you have any questions regarding this change.