### PR TITLE
RegEx fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function DEFAULT_PARSER(path) {
 function DEFAULT_SECOND_PARSER(path, filter) {
   var f = filter
     .replace(/\?/g, '\\?')
-    .replace(/\*/g, '([^/?#]+?)')
+    .replace(/\*/g, '([^/?#]+)')
     .replace(/\.\./, '.*');
   var re = new RegExp(("^" + f + "$"));
   var args = path.match(re);


### PR DESCRIPTION
The regEx does not work well, if there is one route parameter and then the query string follows. In such cases currently only the first character of the route parameter is returned.