### PR TITLE
Add demo of tag-based routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ See also [riot.js.org](http://riot.js.org/api/route/).
 
 - [Page switching](http://riot.js.org/examples/plunker/?app=router-page-switcher)
 - [Complex routings](http://riot.js.org/examples/plunker/?app=router-complex)
+- [Tag-based routing](https://plnkr.co/edit/vp7mgXh89ERC9NIJ4yGK?p=preview)
 
 ## Contribute
 


### PR DESCRIPTION
In the README, add a plunker demo for tag-based routing. It's based on the "Page switching" demo, but uses the `<router>` tag.