### PR TITLE
Fixed a spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Riot Router is the minimal router implementation with such technologies:
 
 - pushState and history API
 - multiple routing groups
-- replacable parser
+- replaceable parser
 - compatible with IE9 and higher
 
 It started as a part of Riot.js, but now it becomes an independent library. It works with or without Riot.js.


### PR DESCRIPTION
an `e` is missing between `c` and `a` for `replaceable parser`