### PR TITLE
history navigation fix following addition of decodeURI in rawth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@riotjs/route",
-  "version": "6.1.0",
+  "version": "7.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/route.standalone.js
+++ b/route.standalone.js
@@ -1031,7 +1031,7 @@
       const hist = getHistory();
       const doc = getDocument(); // update the browser history only if it's necessary
 
-      if (hist && url !== decodeURIComponent(loc.href)) {
+      if (hist && url !== decodeURI(loc.href)) {
         hist.pushState(null, doc.title, url);
       }
     };

--- a/src/dom.js
+++ b/src/dom.js
@@ -19,7 +19,7 @@ const onRouterPush = path => {
   const doc = getDocument()
 
   // update the browser history only if it's necessary
-  if (hist && url !== decodeURIComponent(loc.href)) {
+  if (hist && url !== decodeURI(loc.href)) {
     hist.pushState(null, doc.title, url)
   }
 }

--- a/src/dom.js
+++ b/src/dom.js
@@ -11,21 +11,21 @@ import {defaults, router} from 'rawth'
 import {getDocument, getHistory, getLocation, getWindow} from './util'
 import {has} from 'bianco.attr'
 
-const onWindowEvent = () => router.push(normalizePath(String(getLocation().href)))
+const onWindowEvent = () => router.push(normalizePath(String(getLocation({}).href)))
 const onRouterPush = path => {
   const url = path.includes(defaults.base) ? path : defaults.base + path
-  const loc = getLocation()
+  const loc = getLocation({})
   const hist = getHistory()
   const doc = getDocument()
 
   // update the browser history only if it's necessary
-  if (hist && url !== loc.href) {
+  if (hist && url !== decodeURIComponent(loc.href)) {
     hist.pushState(null, doc.title, url)
   }
 }
 const getLinkElement = node => node && !isLinkNode(node) ? getLinkElement(node.parentNode) : node
 const isLinkNode = node => node.nodeName === LINK_TAG_NAME
-const isCrossOriginLink = path => path.indexOf(getLocation().href.match(RE_ORIGIN)[0]) === -1
+const isCrossOriginLink = path => path.indexOf(getLocation({}).href.match(RE_ORIGIN)[0]) === -1
 const isTargetSelfLink = el => el.target && el.target !== TARGET_SELF_LINK_ATTRIBUTE
 const isEventForbidden = event => (event.which && event.which !== 1) // not left click
   || event.metaKey || event.ctrlKey || event.shiftKey // or meta keys

--- a/src/set-base.js
+++ b/src/set-base.js
@@ -1,13 +1,12 @@
 import {HASH, SLASH} from './constants'
 import {defaults} from 'rawth'
-import {getWindow} from './util'
+import {getLocation} from './util'
 
 export const normalizeInitialSlash = str => str[0] === SLASH ? str : `${SLASH}${str}`
 export const removeTrailingSlash = str => str[str.length - 1] === SLASH ? str.substr(0, str.length - 1) : str
 
 export const normalizeBase = base => {
-  const win = getWindow()
-  const loc = win.location
+  const loc = getLocation()
   const root = loc ? `${loc.protocol}//${loc.host}` : ''
   const {pathname} = loc ? loc : {}
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,7 @@
 export const getWindow = () => typeof window === 'undefined' ? null : window
 export const getDocument = () => typeof document === 'undefined' ? null : document
 export const getHistory = () => typeof history === 'undefined' ? null : history
-export const getLocation = () => {
+export const getLocation = (fallback) => {
   const win = getWindow()
-  return win ? win.location : {}
+  return win ? win.location : fallback
 }


### PR DESCRIPTION
This is a follow-up on issue #155: now that router paths are decoded, the comparison logic in **dom.js** is broken for URLs containing spaces:

```javascript
const onRouterPush = path => {
  const url = path.includes(defaults.base) ? path : defaults.base + path
  const loc = getLocation({})
  const hist = getHistory()
  const doc = getDocument()

  // update the browser history only if it's necessary
  if (hist && url !== loc.href) {                   ////////////////// this comparison is broken
    hist.pushState(null, doc.title, url)
  }
}
```
In the example above `url` is decoded, but `loc.href` is not. This causes the following browser history navigation failure in my case:
* start with  `/`
* go to `/my space` using `<a href="/my space">link</a>`
* click the browser 'back' key ==> back to `/`
* click the browser 'forward' key ==> on `my space` again
* click the browser 'back' key (any number of times) ==> nothing happens

I eventually realized that the first 'forward' resulted in a push to `/my%20space`, which prompted to code above to add one more page `/my space` to history. Clicking'back' then restores `/my%20space`, causing again the `/my space` entry to be added.

This PR wraps `loc.href` above with `decodeURI()`. I tried to review all usages of `location.href`, which prompted me to also factorize further to `getLocation()` all accesses to `window.location`. My understanding is that `getLocation()` is not exported from the router, hence the change of (default) behavior is ok.

**Side-question**: should `rawth` not be using `decodeURI` instead of `decodeURIComponent` ? (as it is applied to multiple components)